### PR TITLE
Add support for sparse matrices

### DIFF
--- a/sympytensor/pytensor.py
+++ b/sympytensor/pytensor.py
@@ -13,7 +13,6 @@ from sympy.utilities.iterables import is_sequence
 mapping = {
     # Numbers
     sp.core.numbers.ImaginaryUnit: lambda: pt.complex(0, 1),
-
     # elemwise funcs
     sp.Add: pt.add,
     sp.Mul: pt.mul,
@@ -211,12 +210,15 @@ class PytensorPrinter(Printer):
 
             return data, idxs, pointers, shape
 
+        print("Hi :)")
+
         dod = X.todod()
         data, idxs, pointers, shape = dod_to_csr(dod)
         data = [self._print(d) for d in data]
 
         return pytensor.sparse.CSR(data, idxs, pointers, shape)
 
+    _print_ImmutableSparseMatrix = _print_MutableSparseMatrix = _print_SparseMatrix
 
     def _print_IndexedBase(self, X, **kwargs):
         dtype = kwargs.get("dtypes", {}).get(X)

--- a/sympytensor/pytensor.py
+++ b/sympytensor/pytensor.py
@@ -210,8 +210,6 @@ class PytensorPrinter(Printer):
 
             return data, idxs, pointers, shape
 
-        print("Hi :)")
-
         dod = X.todod()
         data, idxs, pointers, shape = dod_to_csr(dod)
         data = [self._print(d) for d in data]

--- a/tests/test_pytensor.py
+++ b/tests/test_pytensor.py
@@ -740,3 +740,11 @@ def test_print_reduce_many_d(reduce_op):
     )
 
     assert z.eval({x_pt: x_val, l_pt: 0}) == expected
+
+
+def test_sparse_matrix():
+    X = sp.SparseMatrix(2, 2, {(0, 1): 2, (1, 0): 3})
+    X_pt = as_tensor(X)
+
+    print(X_pt)
+    assert 0

--- a/tests/test_pytensor.py
+++ b/tests/test_pytensor.py
@@ -4,6 +4,8 @@ import numpy as np
 import pytensor
 import pytensor.tensor as pt
 import pytest
+import scipy.sparse
+from numpy.testing import assert_allclose
 from pytensor.graph.basic import Variable
 from pytensor.scalar.basic import ScalarType
 from pytensor.tensor.elemwise import DimShuffle, Elemwise
@@ -296,7 +298,7 @@ def test_pytensor_matrix_funciton_matches_numpy(n_out, scalar):
     if n_out == 1:
         output = np.expand_dims(output, 0)
     for out in output:
-        np.testing.assert_allclose(out, expected)
+        assert_allclose(out, expected)
 
 
 def test_dim_handling():
@@ -746,5 +748,6 @@ def test_sparse_matrix():
     X = sp.SparseMatrix(2, 2, {(0, 1): 2, (1, 0): 3})
     X_pt = as_tensor(X)
 
-    print(X_pt)
-    assert 0
+    assert X_pt.owner.op == pytensor.sparse.CSR
+    assert X_pt.eval() == scipy.sparse.csr_matrix([[0, 2], [3, 0]])
+    assert_allclose(X_pt.eval().todense(), np.array([[0, 2], [3, 0]]))

--- a/tests/test_pytensor.py
+++ b/tests/test_pytensor.py
@@ -722,7 +722,7 @@ def test_print_reduce_2d(i_range: tuple, reduce_op):
 
 
 @pytest.mark.parametrize("reduce_op", [sp.Sum, sp.Product])
-def test_print_sum_many_d(reduce_op):
+def test_print_reduce_many_d(reduce_op):
     cache = {}
     i, j, k, l = sp.symbols("i j k l", cls=sp.Idx)
 


### PR DESCRIPTION
This PR allows one to define sparse matrices in sympy then write them to pytensor sparse CSR matrices. 