### PR TITLE
Print transpose as `pt.matrix_transpose`

### DIFF
--- a/sympytensor/pymc.py
+++ b/sympytensor/pymc.py
@@ -1,5 +1,6 @@
 import pymc as pm
 import pytensor
+import sympy as sp
 
 from sympytensor.pytensor import as_tensor
 
@@ -28,11 +29,15 @@ def _match_cache_to_rvs(cache, model=None):
     return sub_dict
 
 
-def SympyDeterministic(name, expr, model=None, dims=None):
+def SympyDeterministic(name: str, expr: sp.Expr | list[sp.Expr], model=None, dims=None):
     model = pm.modelcontext(model)
     cache = {}
 
-    pytensor_expr = as_tensor(expr, cache=cache)
+    if isinstance(expr, list):
+        pytensor_expr = pytensor.tensor.stack([as_tensor(e, cache=cache) for e in expr])
+    else:
+        pytensor_expr = as_tensor(expr, cache=cache)
+
     replace_dict = _match_cache_to_rvs(cache, model)
 
     pymc_expr = pytensor.graph_replace(pytensor_expr, replace_dict, strict=True)

--- a/sympytensor/pytensor.py
+++ b/sympytensor/pytensor.py
@@ -6,7 +6,7 @@ import pytensor.scalar as ps
 import pytensor.tensor as pt
 import sympy as sp
 from pytensor.raise_op import CheckAndRaise
-from pytensor.tensor.elemwise import DimShuffle, Elemwise
+from pytensor.tensor.elemwise import Elemwise
 from sympy.printing.printer import Printer
 from sympy.utilities.iterables import is_sequence
 
@@ -62,7 +62,7 @@ mapping = {
     sp.Trace: pt.linalg.trace,
     sp.Determinant: pt.linalg.det,
     sp.Inverse: pt.linalg.inv,
-    sp.Transpose: DimShuffle((False, False), [1, 0]),
+    sp.Transpose: pt.matrix_transpose,
 }
 
 

--- a/tests/test_pymc.py
+++ b/tests/test_pymc.py
@@ -66,8 +66,8 @@ def test_make_sympy_deterministic_complex():
     Ab = sp.Matrix([[system, bias]])
     A_rref, pivots = Ab.rref()
 
-    # Solutions are in the last column
-    model = A_rref[:, -1]
+    # Solutions are in the last column. Sympy can't squeeze, so extract the elements into a list
+    model = [elem for elem in A_rref[:, -1]]
     coords = {"variable": ["x_s", "x_d", "P", "P_e", "M_d", "M_s"]}
 
     with pm.Model(coords=coords) as m:


### PR DESCRIPTION
Pytensor changed the signature of `DimShuffle` that broke printing for `sp.transpose`. 