### PR TITLE
Assorted printer map cleanups

### DIFF
--- a/sympytensor/pytensor.py
+++ b/sympytensor/pytensor.py
@@ -2,12 +2,10 @@ from functools import partial
 from typing import Any
 
 import pytensor
-import pytensor.scalar as ps
 import pytensor.tensor as pt
 import sympy as sp
 from pytensor.raise_op import CheckAndRaise
 from pytensor.sparse.variable import SparseVariable
-from pytensor.tensor.elemwise import Elemwise
 from pytensor.tensor.variable import TensorVariable
 from sympy.printing.printer import Printer
 from pytensor import config
@@ -61,9 +59,9 @@ mapping = {
     sp.Min: pt.minimum,  # Sympy accept >2 inputs, Pytensor only 2
     sp.conjugate: pt.conj,
     # Matrices
-    sp.MatAdd: Elemwise(ps.add),
-    sp.HadamardProduct: Elemwise(ps.mul),
-    sp.Trace: pt.linalg.trace,
+    sp.MatAdd: pt.add,
+    sp.HadamardProduct: pt.mul,
+    sp.Trace: pt.trace,
     sp.Determinant: pt.linalg.det,
     sp.Inverse: pt.linalg.inv,
     sp.Transpose: pt.matrix_transpose,

--- a/tests/test_pytensor.py
+++ b/tests/test_pytensor.py
@@ -237,7 +237,7 @@ def test_Trace():
     cache = {}
     result = as_tensor(sp.Trace(A), cache=cache)
     A_pt = get_pt_vars(cache, "A")
-    assert_graph_equal(result, pt.linalg.trace(A_pt))
+    assert_graph_equal(result, pt.trace(A_pt))
 
 
 def test_Determinant():


### PR DESCRIPTION
- `sp.MatAdd` -> `pt.add`
- `sp.HadamardProduct` -> 'pt.mul'
- `sp.Trace` -> 'pt.trace'

Silences a future warning about `pt.linalg.trace`