### PR TITLE
Skip scatter-over-zero pattern when creating a dense symbolic matrix

### DIFF
--- a/sympytensor/pytensor.py
+++ b/sympytensor/pytensor.py
@@ -294,6 +294,10 @@ class PytensorPrinter(Printer):
         symbolic entries.  This minimizes graph nodes to *O(n_symbolic)* instead of *O(n_nonzero)*.
         """
         base, sym_rows, sym_cols, sym_values = self._partition_matrix_elements(X, **kwargs)
+
+        if len(sym_values) == X.rows * X.cols:
+            return pt.stack(sym_values).reshape(X.shape)
+
         X_pt = pt.as_tensor_variable(base)
 
         if not sym_values:

--- a/tests/test_pytensor.py
+++ b/tests/test_pytensor.py
@@ -522,7 +522,8 @@ def test_DenseMatrix():
         cache = {}
         tX = as_tensor(X, cache=cache)
         assert isinstance(tX, TensorVariable)
-        assert isinstance(tX.owner.op, AdvancedIncSubtensor)
+        # All entries symbolic: the scatter-over-zero-base path is bypassed.
+        assert not isinstance(tX.owner.op, AdvancedIncSubtensor)
 
         t_pt = get_pt_vars(cache, ["theta"])
         theta_val = np.pi / 4


### PR DESCRIPTION
For example, given:

```py
X = MatrixType([[sp.cos(t), -sp.sin(t)], [sp.sin(t), sp.cos(t)]])
```

We can just make the matrix, rather than doing set subtensor into every single element.