### PR TITLE
Fix variadic Max/Min, non-concrete Idx bounds, and duplicate guards

### DIFF
--- a/sympytensor/pytensor.py
+++ b/sympytensor/pytensor.py
@@ -1,4 +1,4 @@
-from functools import partial
+from functools import partial, reduce
 from typing import Any
 
 import pytensor
@@ -55,8 +55,6 @@ mapping = {
     sp.Or: pt.bitwise_or,  # bitwise
     sp.Not: pt.invert,  # bitwise
     sp.Xor: pt.bitwise_xor,  # bitwise
-    sp.Max: pt.maximum,  # Sympy accept >2 inputs, Pytensor only 2
-    sp.Min: pt.minimum,  # Sympy accept >2 inputs, Pytensor only 2
     sp.conjugate: pt.conj,
     # Matrices
     sp.MatAdd: pt.add,
@@ -214,6 +212,20 @@ class PytensorPrinter(Printer):
             ) from None
         children = [self._print(arg, **kwargs) for arg in expr.args]
         return op(*children)
+
+    def _fold_binary(self, op, expr, **kwargs):
+        """Left-fold a two-input PyTensor ``op`` over the printed children of a variadic SymPy expression.
+
+        SymPy accepts any number of arguments where the PyTensor counterpart takes exactly two, so splatting the
+        children into the op the way :meth:`_print_Basic` does would fail in ``make_node``.
+        """
+        return reduce(op, [self._print(arg, **kwargs) for arg in expr.args])
+
+    def _print_Max(self, expr, **kwargs):
+        return self._fold_binary(pt.maximum, expr, **kwargs)
+
+    def _print_Min(self, expr, **kwargs):
+        return self._fold_binary(pt.minimum, expr, **kwargs)
 
     def _print_MatrixSymbol(self, X, **kwargs):
         dtype = kwargs.get("dtypes", {}).get(X)
@@ -452,11 +464,7 @@ class PytensorPrinter(Printer):
         return self._print_reduction(X, op="prod", **kwargs)
 
     def _print_MatMul(self, expr, **kwargs):
-        children = [self._print(arg, **kwargs) for arg in expr.args]
-        result = children[0]
-        for child in children[1:]:
-            result = pt.dot(result, child)
-        return result
+        return self._fold_binary(pt.dot, expr, **kwargs)
 
     def _print_Inverse(self, expr, **kwargs):
         # sp.Inverse subclasses sp.MatPow, so without this override the MRO would

--- a/sympytensor/pytensor.py
+++ b/sympytensor/pytensor.py
@@ -105,6 +105,15 @@ def dod_to_csr(
     return data, idxs, pointers, shape
 
 
+def _static_dim(dim: Any) -> int | None:
+    """Coerce a statically known SymPy dimension to a Python ``int``, returning ``None`` for anything else.
+
+    ``getattr`` rather than attribute access so that a missing dimension (``None``) is handled alongside
+    symbolic and non-finite ones such as ``sympy.oo``.
+    """
+    return int(dim) if getattr(dim, "is_Integer", False) else None
+
+
 class PytensorPrinter(Printer):
     """Code printer that converts SymPy expressions into PyTensor symbolic expression graphs.
 
@@ -249,18 +258,18 @@ class PytensorPrinter(Printer):
             dtype = "int32"
 
         bc = kwargs.get("broadcastables", {}).get(i)
-        if i.lower is None and i.upper is None:
-            return self._get_or_create(i, dtype=dtype, shape=bc)
-        elif i.lower is None:
-            valid_range = (0, int(i.upper.evalf() + 1))
-        else:
-            valid_range = (int(i.lower.evalf()), int(i.upper.evalf() + 1))
+        i_pt = self._get_or_create(i, dtype=dtype, shape=bc)
 
-        i = self._get_or_create(i, dtype=dtype, shape=bc)
-        all_true_scalar = pt.all([pt.ge(i, valid_range[0]), pt.lt(i, valid_range[1])])
+        lower = _static_dim(i.lower)
+        upper = _static_dim(i.upper)
+        if lower is None or upper is None:
+            return i_pt
+
+        valid_range = (lower, upper + 1)
+        in_range = pt.all([pt.ge(i_pt, valid_range[0]), pt.lt(i_pt, valid_range[1])])
         msg = f"Index {i.name} out of valid range {valid_range[0]} - {valid_range[1]}"
 
-        return CheckAndRaise(IndexError, msg)(i, all_true_scalar)
+        return CheckAndRaise(IndexError, msg)(i_pt, in_range)
 
     def _partition_matrix_elements(self, X: sp.matrices.dense.DenseMatrix, **kwargs):
         """Partition matrix entries into a numeric base array and symbolic overlay lists.

--- a/sympytensor/pytensor.py
+++ b/sympytensor/pytensor.py
@@ -131,6 +131,10 @@ class PytensorPrinter(Printer):
 
     def __init__(self, *args, **kwargs):
         self.cache = kwargs.pop("cache", {})
+
+        # Index range guards are memoized apart from `cache`, whose keys are 5-tuples that consumers unpack
+        # positionally and whose size is part of the public contract.
+        self._range_checks = {}
         super().__init__(*args, **kwargs)
 
     def _print(self, expr, **kwargs):
@@ -266,10 +270,16 @@ class PytensorPrinter(Printer):
             return i_pt
 
         valid_range = (lower, upper + 1)
+        guard_key = (*self._get_key(i, dtype=dtype, shape=bc), valid_range)
+        if guard_key in self._range_checks:
+            return self._range_checks[guard_key]
+
         in_range = pt.all([pt.ge(i_pt, valid_range[0]), pt.lt(i_pt, valid_range[1])])
         msg = f"Index {i.name} out of valid range {valid_range[0]} - {valid_range[1]}"
 
-        return CheckAndRaise(IndexError, msg)(i_pt, in_range)
+        checked = CheckAndRaise(IndexError, msg)(i_pt, in_range)
+        self._range_checks[guard_key] = checked
+        return checked
 
     def _partition_matrix_elements(self, X: sp.matrices.dense.DenseMatrix, **kwargs):
         """Partition matrix entries into a numeric base array and symbolic overlay lists.

--- a/tests/test_printer_indexing.py
+++ b/tests/test_printer_indexing.py
@@ -95,6 +95,18 @@ def test_indexed_symbolic_shape():
     assert x.type.shape == ()
 
 
+def test_Idx_guard_emitted_once():
+    i = sp.Idx("i", range=10)
+
+    cache = {}
+    x = as_tensor(sp.IndexedBase("A")[i] * sp.IndexedBase("B")[i], cache=cache)
+    assert count_range_checks(x) == 1
+
+    i_pt, a_pt, b_pt = get_pt_vars(cache, ["i", "A", "B"])
+    with pytest.raises(IndexError):
+        x.eval({a_pt: np.zeros(10), b_pt: np.zeros(10), i_pt: 10})
+
+
 def test_sliced_indexbase_1d():
     cache = {}
     x = sp.IndexedBase("x", shape=(10,))

--- a/tests/test_printer_indexing.py
+++ b/tests/test_printer_indexing.py
@@ -1,12 +1,18 @@
 import numpy as np
 import pytest
 from numpy.testing import assert_allclose
+from pytensor.graph.traversal import ancestors
+from pytensor.raise_op import CheckAndRaise
 
 import sympy as sp
 
 from sympytensor.pytensor import PytensorPrinter, as_tensor
 
 from tests.helpers import get_pt_vars
+
+
+def count_range_checks(x):
+    return sum(var.owner is not None and isinstance(var.owner.op, CheckAndRaise) for var in ancestors([x]))
 
 
 def test_indexedbase():
@@ -63,6 +69,30 @@ def test_indexedbase_with_index_and_no_range():
     i_pt, j_pt, x_pt = get_pt_vars(cache, ["i", "j", "x"])
 
     assert x.eval({x_pt: np.arange(20).reshape((10, 2)), i_pt: 5, j_pt: 1}) == 11.0
+
+
+def test_Idx_non_concrete_bounds_unguarded():
+    k = sp.Idx("k", (1, sp.oo))
+
+    cache = {}
+    x = as_tensor(sp.IndexedBase("x")[k], cache=cache)
+    assert count_range_checks(x) == 0
+
+    k_pt, x_pt = get_pt_vars(cache, ["k", "x"])
+    assert x.eval({x_pt: np.arange(10.0), k_pt: 3}) == 3.0
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="_print_Indexed coerces base dimensions with a bare int(); fixed by the _static_dim read in commit 1.5",
+)
+def test_indexed_symbolic_shape():
+    n = sp.Symbol("n", integer=True)
+    i = sp.Idx("i")
+
+    cache = {}
+    x = as_tensor(sp.IndexedBase("A", shape=(n,))[i], cache=cache)
+    assert x.type.shape == ()
 
 
 def test_sliced_indexbase_1d():

--- a/tests/test_printer_scalars.py
+++ b/tests/test_printer_scalars.py
@@ -126,6 +126,18 @@ def test_binary_mapping(f_sp, f_pt):
 
 
 @pytest.mark.parametrize(
+    "f_sp, expected",
+    [(sp.Max, 5.0), (sp.Min, -1.0)],
+    ids=["Max", "Min"],
+)
+def test_Max_Min_variadic(f_sp, expected):
+    cache = {}
+    result = as_tensor(f_sp(x, y, z), cache=cache)
+    x_pt, y_pt, z_pt = get_pt_vars(cache, ["x", "y", "z"])
+    assert_allclose(result.eval({x_pt: 2.0, y_pt: 5.0, z_pt: -1.0}), expected)
+
+
+@pytest.mark.parametrize(
     "f_sp, f_pt",
     [
         (sp.re, pt.real),


### PR DESCRIPTION
Three printer bugs: `Max`/`Min` with more than two arguments blew up inside PyTensor's `make_node`, an `Idx` with a symbolic or infinite bound couldn't be printed at all, and every use of a bounded index added another copy of the same range check. The guards are memoized in their own dict rather than the printer cache, because `pymc.py` unpacks those cache keys positionally as 5-tuples.

`test_indexed_symbolic_shape` is a strict xfail — the remaining bare `int()` is in `_print_Indexed`, so whichever follow-up fixes that has to drop the marker or the suite goes red.

Stacked on #32.
