### PR TITLE
Assert printer results instead of PyTensor internals

### DIFF
--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -3,6 +3,7 @@ import pytensor
 import pytensor.tensor as pt
 from pytensor.graph.basic import equal_computations
 from pytensor.graph.traversal import graph_inputs
+from pytensor.tensor.variable import TensorVariable
 from scipy import sparse
 
 import sympy as sp
@@ -85,6 +86,21 @@ def assert_graph_equal(actual, expected, in_actual=None, in_expected=None):
         f"  Actual:   {pytensor.printing.debugprint(actual, file='str')}\n"
         f"  Expected: {pytensor.printing.debugprint(expected, file='str')}"
     )
+
+
+def assert_slice_equal(actual, expected):
+    """Assert two slices agree attribute by attribute, comparing symbolic bounds as graphs."""
+    for attr in ("start", "stop", "step"):
+        a, e = getattr(actual, attr), getattr(expected, attr)
+        assert (a is None) == (e is None), f"slice.{attr} mismatch: {a} vs {e}"
+
+        if a is None:
+            continue
+
+        if isinstance(a, TensorVariable):
+            assert_graph_equal(a, e)
+        else:
+            assert a == e, f"slice.{attr} mismatch: {a} vs {e}"
 
 
 def sparse_allclose(A, B, atol=1e-8):

--- a/tests/test_printer_matrices.py
+++ b/tests/test_printer_matrices.py
@@ -13,7 +13,7 @@ from sympy.abc import x, y
 
 from sympytensor.pytensor import as_tensor, pytensor_function
 
-from tests.helpers import X, Y, Z, assert_graph_equal, get_pt_vars
+from tests.helpers import X, Y, Z, assert_graph_equal, assert_slice_equal, get_pt_vars
 
 
 def test_Trace():
@@ -61,17 +61,6 @@ def test_MatAdd():
 
 def test_slice():
     assert as_tensor(slice(1, 2, 3)) == slice(1, 2, 3)
-
-    def assert_slice_equal(s1, s2):
-        for attr in ["start", "stop", "step"]:
-            a1 = getattr(s1, attr)
-            a2 = getattr(s2, attr)
-            if a1 is None or a2 is None:
-                assert a1 is None and a2 is None, f"slice.{attr} mismatch: {a1} vs {a2}"
-            elif isinstance(a1, TensorVariable) and isinstance(a2, TensorVariable):
-                assert_graph_equal(a1, a2)
-            else:
-                assert a1 == a2, f"slice.{attr} mismatch: {a1} vs {a2}"
 
     dtypes = {x: "int32", y: "int32"}
     cache = {}

--- a/tests/test_printer_matrices.py
+++ b/tests/test_printer_matrices.py
@@ -2,11 +2,8 @@ import numpy as np
 import pytensor.tensor as pt
 import pytest
 from numpy.testing import assert_allclose
+from pytensor import config
 from pytensor.graph.basic import equal_computations
-from pytensor.scalar.basic import ScalarType
-from pytensor.tensor.elemwise import DimShuffle, Elemwise
-from pytensor.tensor.subtensor import AdvancedIncSubtensor
-from pytensor.tensor.variable import TensorVariable
 
 import sympy as sp
 from sympy.abc import x, y
@@ -42,21 +39,27 @@ def test_HadamardProduct():
 
 
 def test_MatMul():
-    expr = X * Y * Z
     cache = {}
-    expr_t = as_tensor(expr, cache=cache)
-    Xt, Yt, Zt = get_pt_vars(cache, ["X", "Y", "Z"])
-    expected = pt.dot(pt.dot(Xt, Yt), Zt)
-    assert_graph_equal(expr_t, expected)
+    expr_pt = as_tensor(X * Y * Z, cache=cache)
+    X_pt, Y_pt, Z_pt = get_pt_vars(cache, ["X", "Y", "Z"])
+    assert_graph_equal(expr_pt, pt.dot(pt.dot(X_pt, Y_pt), Z_pt))
 
 
 def test_Transpose():
-    assert isinstance(as_tensor(X.T).owner.op, DimShuffle)
+    cache = {}
+    expr_pt = as_tensor(X.T, cache=cache)
+    X_pt = get_pt_vars(cache, "X")
+    X_val = np.arange(16.0).reshape(4, 4)
+    assert_allclose(expr_pt.eval({X_pt: X_val}), X_val.T)
 
 
 def test_MatAdd():
-    expr = X + Y + Z
-    assert isinstance(as_tensor(expr).owner.op, Elemwise)
+    cache = {}
+    expr_pt = as_tensor(X + Y + Z, cache=cache)
+    X_pt, Y_pt, Z_pt = get_pt_vars(cache, ["X", "Y", "Z"])
+    values = [np.arange(16.0).reshape(4, 4) * scale for scale in (1, 2, 3)]
+    result = expr_pt.eval(dict(zip([X_pt, Y_pt, Z_pt], values)))
+    assert_allclose(result, sum(values))
 
 
 def test_slice():
@@ -74,84 +77,109 @@ def test_slice():
     assert_slice_equal(actual_slice, slice(1, x_pt, 3))
 
 
-def test_MatrixSlice():
-    cache = {}
-
+def test_MatrixSlice_constant_bounds():
     n = sp.Symbol("n", integer=True)
     X = sp.MatrixSymbol("X", n, n)
 
-    Y = X[1:2:3, 4:5:6]
-    Yt = as_tensor(Y, cache=cache)
+    cache = {}
+    Y_pt = as_tensor(X[1:2:3, 4:5:6], cache=cache)
+    X_pt = get_pt_vars(cache, "X")
 
-    assert tuple(Yt.owner.op.idx_list) == (slice(0, 1, 2), slice(3, 4, 5))
-    assert Yt.owner.inputs[0] == as_tensor(X, cache=cache)
-    assert all(Yt.owner.inputs[i].data == i for i in range(1, 7))
+    X_val = np.arange(100.0).reshape(10, 10)
+    assert_allclose(Y_pt.eval({X_pt: X_val}), X_val[1:2:3, 4:5:6])
 
-    k = sp.Symbol("k")
-    start, stop, step = 4, k, 2
-    Y = X[start:stop:step]
-    Yt = as_tensor(Y, dtypes={n: "int32", k: "int32"})
-    stop_pos = Yt.owner.op.idx_list[0].stop
-    assert Yt.owner.inputs[1 + stop_pos].type == ScalarType("int32")
+
+def test_MatrixSlice_symbolic_bound():
+    n = sp.Symbol("n", integer=True)
+    k = sp.Symbol("k", integer=True)
+    X = sp.MatrixSymbol("X", n, n)
+
+    cache = {}
+    Y_pt = as_tensor(X[4:k:2], dtypes={n: "int32", k: "int32"}, cache=cache)
+    X_pt, k_pt, n_pt = get_pt_vars(cache, ["X", "k", "n"])
+
+    assert (k_pt.type.dtype, n_pt.type.dtype) == ("int32", "int32")
+
+    X_val = np.arange(100.0).reshape(10, 10)
+    result = Y_pt.eval({X_pt: X_val, k_pt: np.int32(9), n_pt: np.int32(10)})
+    assert_allclose(result, X_val[4:9:2, :])
 
 
 def test_BlockMatrix():
     n = sp.Symbol("n", integer=True)
     A, B, C, D = (sp.MatrixSymbol(name, n, n) for name in "ABCD")
     cache = {}
-    Block = sp.BlockMatrix([[A, B], [C, D]])
-    Blockt = as_tensor(Block, cache=cache)
-    At, Bt, Ct, Dt = get_pt_vars(cache, ["A", "B", "C", "D"])
-    solutions = [
-        pt.join(0, pt.join(1, At, Bt), pt.join(1, Ct, Dt)),
-        pt.join(1, pt.join(0, At, Ct), pt.join(0, Bt, Dt)),
+    block_pt = as_tensor(sp.BlockMatrix([[A, B], [C, D]]), cache=cache)
+    A_pt, B_pt, C_pt, D_pt = get_pt_vars(cache, ["A", "B", "C", "D"])
+    accepted_graphs = [
+        pt.join(0, pt.join(1, A_pt, B_pt), pt.join(1, C_pt, D_pt)),
+        pt.join(1, pt.join(0, A_pt, C_pt), pt.join(0, B_pt, D_pt)),
     ]
-    assert any(equal_computations([Blockt], [sol]) for sol in solutions)
+    assert any(equal_computations([block_pt], [graph]) for graph in accepted_graphs)
 
 
-def test_DenseMatrix():
+def jacobian_of_squares(symbols):
+    """Jacobian of ``[x**2 for x in symbols]`` -- a diagonal matrix holding ``2 * x``."""
+    return sp.Matrix([symbol**2 for symbol in symbols]).jacobian(symbols)
+
+
+@pytest.mark.parametrize("MatrixType", [sp.Matrix, sp.ImmutableMatrix], ids=["Matrix", "ImmutableMatrix"])
+def test_DenseMatrix(MatrixType):
     theta = sp.Symbol("theta")
-    for MatrixType in [sp.Matrix, sp.ImmutableMatrix]:
-        X = MatrixType([[sp.cos(theta), -sp.sin(theta)], [sp.sin(theta), sp.cos(theta)]])
-        cache = {}
-        tX = as_tensor(X, cache=cache)
-        assert isinstance(tX, TensorVariable)
-        assert isinstance(tX.owner.op, AdvancedIncSubtensor)
+    rotation = MatrixType([[sp.cos(theta), -sp.sin(theta)], [sp.sin(theta), sp.cos(theta)]])
 
-        theta_pt = get_pt_vars(cache, ["theta"])
-        theta_val = np.pi / 4
-        result = tX.eval({theta_pt: theta_val})
-        expected = np.array(
-            [
-                [np.cos(theta_val), -np.sin(theta_val)],
-                [np.sin(theta_val), np.cos(theta_val)],
-            ]
-        )
-        assert_allclose(result, expected)
+    cache = {}
+    X_pt = as_tensor(rotation, cache=cache)
+    theta_pt = get_pt_vars(cache, "theta")
+
+    theta_val = np.pi / 4
+    expected = np.array(
+        [
+            [np.cos(theta_val), -np.sin(theta_val)],
+            [np.sin(theta_val), np.cos(theta_val)],
+        ]
+    )
+    assert_allclose(X_pt.eval({theta_pt: theta_val}), expected)
+
+
+def test_dense_matrix_fills_numeric_base_then_sets_symbolic_entries():
+    """A symbolic dense matrix becomes a constant base plus one set-subtensor.
+
+    Stacking every cell would evaluate identically, so the structure is what
+    distinguishes the two strategies: the numeric entries have to be folded into the
+    constant base, leaving only the symbolic ones in the graph.
+    """
+    symbols = [sp.Symbol(f"x_{i}") for i in range(3)]
+
+    cache = {}
+    jacobian_pt = as_tensor(jacobian_of_squares(symbols), cache=cache)
+    x_pt = get_pt_vars(cache, [symbol.name for symbol in symbols])
+
+    diagonal = pt.as_tensor([0, 1, 2])
+    base = pt.as_tensor_variable(np.zeros((3, 3), dtype=config.floatX))
+    expected = base[diagonal, diagonal].set([2 * symbol_pt for symbol_pt in x_pt])
+
+    assert_graph_equal(jacobian_pt, expected)
 
 
 def test_empty_matrix():
     X = sp.Matrix([[0 for _ in range(20)] for _ in range(20)])
-    tX = as_tensor(X)
-    assert np.allclose(tX.eval(), np.zeros((20, 20)))
+    X_pt = as_tensor(X)
+    assert np.allclose(X_pt.eval(), np.zeros((20, 20)))
 
 
 def test_large_dense_matrix():
-    vars = [sp.Symbol(f"x_{i}") for i in range(100)]
+    symbols = [sp.Symbol(f"x_{i}") for i in range(100)]
 
-    eqs = sp.Matrix([x**2 for x in vars])
-    jac = eqs.jacobian(vars)
+    cache = {}
+    jacobian_pt = as_tensor(jacobian_of_squares(symbols), cache=cache)
+    values = np.arange(1.0, 1.0 + len(symbols))
+    symbol_values = dict(zip(get_pt_vars(cache, [symbol.name for symbol in symbols]), values))
 
-    jac_pt = as_tensor(jac)
+    assert_allclose(jacobian_pt.eval(symbol_values), np.diag(2 * values))
 
-    assert isinstance(jac_pt.owner.op, AdvancedIncSubtensor)
 
-    small_eqs = sp.Matrix([x**2 for x in vars[:3]])
-    small_jac = small_eqs.jacobian(vars[:3])
-    small_jac_pt = as_tensor(small_jac)
-
-    assert isinstance(small_jac_pt.owner.op, AdvancedIncSubtensor)
-
+def test_large_constant_matrix_is_folded():
     const_matrix = sp.ones(50, 50)
     const_pt = as_tensor(const_matrix)
     assert const_pt.owner is None
@@ -237,7 +265,7 @@ def test_Inverse_times_vector():
 def test_MatPow_large_exponent_uses_matrix_power():
     A = sp.MatrixSymbol("A", 3, 3)
     f = pytensor_function([A], [A**8], dims={A: 2})
-    dot_nodes = [n for n in f.maker.fgraph.toposort() if "dot" in type(n.op).__name__.lower()]
+    dot_nodes = [node for node in f.maker.fgraph.toposort() if "dot" in type(node.op).__name__.lower()]
     assert len(dot_nodes) <= 4
 
 

--- a/tests/test_printer_sparse.py
+++ b/tests/test_printer_sparse.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pytensor
 from numpy.testing import assert_allclose
 from scipy import sparse
 
@@ -16,17 +15,18 @@ def test_sparse_matrix():
     y = sp.SparseMatrix(2, 1, {(0, 0): a, (1, 0): b})
     z = X @ y
 
-    X_pt = as_tensor(X)
+    X_value = as_tensor(X).eval()
 
-    assert X_pt.owner.op == pytensor.sparse.CSR
-    assert sparse_allclose(X_pt.eval(), sparse.csr_matrix([[0, 2], [3, 0]]))
+    assert X_value.format == "csr"
+    assert sparse_allclose(X_value, sparse.csr_matrix([[0, 2], [3, 0]]))
 
     cache = {}
     z_pt = as_tensor(z, cache=cache)
     a_pt, b_pt = get_pt_vars(cache, ["a", "b"])
+    z_value = z_pt.eval({a_pt: 1, b_pt: 2})
 
-    assert z_pt.owner.op == pytensor.sparse.CSR
-    assert sparse_allclose(z_pt.eval({a_pt: 1, b_pt: 2}), sparse.csr_matrix([[4], [3]]))
+    assert z_value.format == "csr"
+    assert sparse_allclose(z_value, sparse.csr_matrix([[4], [3]]))
 
 
 def test_dod_to_csr_empty():

--- a/tests/test_pytensor_function.py
+++ b/tests/test_pytensor_function.py
@@ -92,6 +92,19 @@ function_dim_cases = [
 ]
 
 
+UNKNOWN_DIM_LENGTH = 5
+
+
+def call_with_ones(f):
+    """Call a compiled function on all-ones inputs, returning its outputs as a list."""
+    in_values = [
+        np.ones(tuple(UNKNOWN_DIM_LENGTH if dim is None else dim for dim in var.type.shape)) for var in f.input_storage
+    ]
+    out_values = f(*in_values)
+
+    return out_values if isinstance(out_values, list) else [out_values]
+
+
 @pytest.mark.parametrize(
     "inputs, outputs, in_dims, out_dims",
     function_dim_cases,
@@ -99,18 +112,11 @@ function_dim_cases = [
 )
 def test_printing_scalar_function(inputs, outputs, in_dims, out_dims):
     f = pytensor_function(inputs, outputs, dims=in_dims)
-
     assert isinstance(f, Function)
 
-    in_values = [np.ones(tuple(d if d is not None else 5 for d in i.type.shape)) for i in f.input_storage]
-    out_values = f(*in_values)
-    if not isinstance(out_values, list):
-        out_values = [out_values]
+    out_values = call_with_ones(f)
 
-    assert len(out_dims) == len(out_values)
-    for d, value in zip(out_dims, out_values):
-        assert isinstance(value, np.ndarray)
-        assert value.ndim == d
+    assert [value.ndim for value in out_values] == out_dims
 
 
 def test_pytensor_function_raises_on_bad_kwarg():


### PR DESCRIPTION
Several printer tests asserted on PyTensor op classes, and one on a positional graph-input index, so a dependency bump breaks them whether or not the printer changed. Those now evaluate the graph and compare against numpy. The one case where structure genuinely is the claim — a symbolic dense matrix has to fold its numeric entries into a constant base and set only the symbolic ones — writes out the expected graph and compares with `equal_computations`, since stacking every cell evaluates identically and only the structure tells the two apart.

Also fixes the nested slice-comparison helper, whose both-`None` branch quietly passed when neither slice had the attribute it was meant to compare.

Stacked on #32.
