### PR TITLE
Fix printer defects and stop asserting on PyTensor internals

### DIFF
--- a/sympytensor/pytensor.py
+++ b/sympytensor/pytensor.py
@@ -1,4 +1,4 @@
-from functools import partial
+from functools import partial, reduce
 from typing import Any
 
 import pytensor
@@ -55,8 +55,6 @@ mapping = {
     sp.Or: pt.bitwise_or,  # bitwise
     sp.Not: pt.invert,  # bitwise
     sp.Xor: pt.bitwise_xor,  # bitwise
-    sp.Max: pt.maximum,  # Sympy accept >2 inputs, Pytensor only 2
-    sp.Min: pt.minimum,  # Sympy accept >2 inputs, Pytensor only 2
     sp.conjugate: pt.conj,
     # Matrices
     sp.MatAdd: pt.add,
@@ -102,6 +100,15 @@ def dod_to_csr(dod: dict[int, dict[int, Any]], shape: tuple[int, int]) -> tuple[
     return data, indices, indptr
 
 
+def _static_dim(dim: Any) -> int | None:
+    """Coerce a statically known SymPy dimension to a Python ``int``, returning ``None`` for anything else.
+
+    ``getattr`` rather than attribute access so that a missing dimension (``None``) is handled alongside
+    symbolic and non-finite ones such as ``sympy.oo``.
+    """
+    return int(dim) if getattr(dim, "is_Integer", False) else None
+
+
 class PytensorPrinter(Printer):
     """Code printer that converts SymPy expressions into PyTensor symbolic expression graphs.
 
@@ -119,6 +126,10 @@ class PytensorPrinter(Printer):
 
     def __init__(self, *args, **kwargs):
         self.cache = kwargs.pop("cache", {})
+
+        # Index range guards are memoized apart from `cache`, whose keys are 5-tuples that consumers unpack
+        # positionally and whose size is part of the public contract.
+        self._range_checks = {}
         super().__init__(*args, **kwargs)
 
     def _print(self, expr, **kwargs):
@@ -210,6 +221,20 @@ class PytensorPrinter(Printer):
         children = [self._print(arg, **kwargs) for arg in expr.args]
         return op(*children)
 
+    def _fold_binary(self, op, expr, **kwargs):
+        """Left-fold a two-input PyTensor ``op`` over the printed children of a variadic SymPy expression.
+
+        SymPy accepts any number of arguments where the PyTensor counterpart takes exactly two, so splatting the
+        children into the op the way :meth:`_print_Basic` does would fail in ``make_node``.
+        """
+        return reduce(op, [self._print(arg, **kwargs) for arg in expr.args])
+
+    def _print_Max(self, expr, **kwargs):
+        return self._fold_binary(pt.maximum, expr, **kwargs)
+
+    def _print_Min(self, expr, **kwargs):
+        return self._fold_binary(pt.minimum, expr, **kwargs)
+
     def _print_MatrixSymbol(self, X, **kwargs):
         dtype = kwargs.get("dtypes", {}).get(X)
         shape = tuple(int(d) if d.is_Integer else None for d in X.shape)
@@ -232,18 +257,24 @@ class PytensorPrinter(Printer):
             dtype = "int32"
 
         bc = kwargs.get("broadcastables", {}).get(i)
-        if i.lower is None and i.upper is None:
-            return self._get_or_create(i, dtype=dtype, shape=bc)
-        elif i.lower is None:
-            valid_range = (0, int(i.upper.evalf() + 1))
-        else:
-            valid_range = (int(i.lower.evalf()), int(i.upper.evalf() + 1))
+        i_pt = self._get_or_create(i, dtype=dtype, shape=bc)
 
-        i = self._get_or_create(i, dtype=dtype, shape=bc)
-        all_true_scalar = pt.all([pt.ge(i, valid_range[0]), pt.lt(i, valid_range[1])])
+        lower = _static_dim(i.lower)
+        upper = _static_dim(i.upper)
+        if lower is None or upper is None:
+            return i_pt
+
+        valid_range = (lower, upper + 1)
+        guard_key = (*self._get_key(i, dtype=dtype, shape=bc), valid_range)
+        if guard_key in self._range_checks:
+            return self._range_checks[guard_key]
+
+        in_range = pt.all([pt.ge(i_pt, valid_range[0]), pt.lt(i_pt, valid_range[1])])
         msg = f"Index {i.name} out of valid range {valid_range[0]} - {valid_range[1]}"
 
-        return CheckAndRaise(IndexError, msg)(i, all_true_scalar)
+        checked = CheckAndRaise(IndexError, msg)(i_pt, in_range)
+        self._range_checks[guard_key] = checked
+        return checked
 
     def _partition_matrix_elements(self, X: sp.matrices.dense.DenseMatrix, **kwargs):
         """Partition matrix entries into a numeric base array and symbolic overlay lists.
@@ -447,11 +478,7 @@ class PytensorPrinter(Printer):
         return self._print_reduction(X, op="prod", **kwargs)
 
     def _print_MatMul(self, expr, **kwargs):
-        children = [self._print(arg, **kwargs) for arg in expr.args]
-        result = children[0]
-        for child in children[1:]:
-            result = pt.dot(result, child)
-        return result
+        return self._fold_binary(pt.dot, expr, **kwargs)
 
     def _print_Inverse(self, expr, **kwargs):
         # sp.Inverse subclasses sp.MatPow, so without this override the MRO would

--- a/sympytensor/pytensor.py
+++ b/sympytensor/pytensor.py
@@ -68,9 +68,7 @@ mapping = {
 }
 
 
-def dod_to_csr(
-    dod: dict[int, dict[int, Any]], shape: tuple[int, int]
-) -> tuple[list, list[int], list[int], tuple[int, int]]:
+def dod_to_csr(dod: dict[int, dict[int, Any]], shape: tuple[int, int]) -> tuple[list, list[int], list[int]]:
     """Convert a dictionary-of-dictionaries sparse representation to compressed sparse row (CSR).
 
     Parameters
@@ -88,23 +86,20 @@ def dod_to_csr(
         Column indices corresponding to each entry in `data`.
     indptr : list of int
         Row pointer array of length ``n_rows + 1``.
-    shape : tuple of int
-        The input `shape`, passed through unchanged.
     """
-    n_rows, n_cols = shape
+    n_rows, _ = shape
 
     data = []
-    idxs = []
-    pointers = [0]
+    indices = []
+    indptr = [0]
 
     for row in range(n_rows):
-        if row in dod:
-            for col in sorted(dod[row].keys()):
-                data.append(dod[row][col])
-                idxs.append(col)
-        pointers.append(len(data))
+        for col in sorted(dod.get(row, {})):
+            data.append(dod[row][col])
+            indices.append(col)
+        indptr.append(len(data))
 
-    return data, idxs, pointers, shape
+    return data, indices, indptr
 
 
 class PytensorPrinter(Printer):
@@ -335,14 +330,14 @@ class PytensorPrinter(Printer):
         Optimizes for the all-numeric case by bypassing printer dispatch.
         """
         dod = X.todod()
-        data, idxs, pointers, shape = dod_to_csr(dod, shape=X.shape)
+        data, indices, indptr = dod_to_csr(dod, shape=X.shape)
 
         if all(isinstance(d, sp.Basic) and d.is_number for d in data):
             data = [float(d.evalf()) for d in data]
         else:
             data = [self._print(d, **kwargs) for d in data]
 
-        return pytensor.sparse.CSR(data, idxs, pointers, shape)
+        return pytensor.sparse.CSR(data, indices, indptr, X.shape)
 
     _print_ImmutableSparseMatrix = _print_MutableSparseMatrix = _print_SparseMatrix
 
@@ -605,7 +600,9 @@ def dim_handling(
     dim : int, optional
         Common number of dimensions for all inputs.  Overrides other arguments if given.
     dims : dict of sympy.Symbol to int, optional
-        Mapping from input symbols to number of dimensions.  Overrides `broadcastables` if given.
+        Mapping from input symbols to number of dimensions.  Overrides `broadcastables` if given.  Every key must
+        appear in `inputs`.  Symbols in `inputs` that are absent from `dims` are omitted from the result, and are
+        therefore treated downstream as scalars with broadcastable pattern ``()``.
     broadcastables : dict of sympy.Symbol to tuple of bool, optional
         Explicit broadcastable values.  Returned unchanged if not ``None``.
 
@@ -613,12 +610,21 @@ def dim_handling(
     -------
     result : dict of sympy.Symbol to tuple of bool
         Dictionary mapping elements of `inputs` to their broadcastable tuples.
+
+    Raises
+    ------
+    ValueError
+        If `dims` contains symbols that are not in `inputs`.
     """
     if dim is not None:
         return {s: (False,) * dim for s in inputs}
 
     if dims is not None:
-        maxdim = max(dims.values())
+        unknown_symbols = sorted(str(s) for s in set(dims) - set(inputs))
+        if unknown_symbols:
+            raise ValueError(f"`dims` contains symbols not in `inputs`: {unknown_symbols}")
+
+        maxdim = max(dims.values(), default=0)
         return {s: (False,) * d + (True,) * (maxdim - d) for s, d in dims.items()}
 
     if broadcastables is not None:

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -3,6 +3,7 @@ import pytensor
 import pytensor.tensor as pt
 from pytensor.graph.basic import equal_computations
 from pytensor.graph.traversal import graph_inputs
+from pytensor.tensor.variable import TensorVariable
 from scipy import sparse
 
 import sympy as sp
@@ -85,6 +86,21 @@ def assert_graph_equal(actual, expected, in_actual=None, in_expected=None):
         f"  Actual:   {pytensor.printing.debugprint(actual, file='str')}\n"
         f"  Expected: {pytensor.printing.debugprint(expected, file='str')}"
     )
+
+
+def assert_slice_equal(actual, expected):
+    """Assert two slices agree attribute by attribute, comparing symbolic bounds as graphs."""
+    for attr in ("start", "stop", "step"):
+        a, e = getattr(actual, attr), getattr(expected, attr)
+        assert (a is None) == (e is None), f"slice.{attr} mismatch: {a} vs {e}"
+
+        if a is None:
+            continue
+
+        if isinstance(a, TensorVariable):
+            assert_graph_equal(a, e)
+        else:
+            assert a == e, f"slice.{attr} mismatch: {a} vs {e}"
 
 
 def sparse_allclose(A, B, atol=1e-8):

--- a/tests/test_printer_indexing.py
+++ b/tests/test_printer_indexing.py
@@ -1,12 +1,18 @@
 import numpy as np
 import pytest
 from numpy.testing import assert_allclose
+from pytensor.graph.traversal import ancestors
+from pytensor.raise_op import CheckAndRaise
 
 import sympy as sp
 
 from sympytensor.pytensor import PytensorPrinter, as_tensor
 
 from tests.helpers import get_pt_vars
+
+
+def count_range_checks(x):
+    return sum(var.owner is not None and isinstance(var.owner.op, CheckAndRaise) for var in ancestors([x]))
 
 
 def test_indexedbase():
@@ -63,6 +69,42 @@ def test_indexedbase_with_index_and_no_range():
     i_pt, j_pt, x_pt = get_pt_vars(cache, ["i", "j", "x"])
 
     assert x.eval({x_pt: np.arange(20).reshape((10, 2)), i_pt: 5, j_pt: 1}) == 11.0
+
+
+def test_Idx_non_concrete_bounds_unguarded():
+    k = sp.Idx("k", (1, sp.oo))
+
+    cache = {}
+    x = as_tensor(sp.IndexedBase("x")[k], cache=cache)
+    assert count_range_checks(x) == 0
+
+    k_pt, x_pt = get_pt_vars(cache, ["k", "x"])
+    assert x.eval({x_pt: np.arange(10.0), k_pt: 3}) == 3.0
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="_print_Indexed coerces base dimensions with a bare int(); fixed by the _static_dim read in commit 1.5",
+)
+def test_indexed_symbolic_shape():
+    n = sp.Symbol("n", integer=True)
+    i = sp.Idx("i")
+
+    cache = {}
+    x = as_tensor(sp.IndexedBase("A", shape=(n,))[i], cache=cache)
+    assert x.type.shape == ()
+
+
+def test_Idx_guard_emitted_once():
+    i = sp.Idx("i", range=10)
+
+    cache = {}
+    x = as_tensor(sp.IndexedBase("A")[i] * sp.IndexedBase("B")[i], cache=cache)
+    assert count_range_checks(x) == 1
+
+    i_pt, a_pt, b_pt = get_pt_vars(cache, ["i", "A", "B"])
+    with pytest.raises(IndexError):
+        x.eval({a_pt: np.zeros(10), b_pt: np.zeros(10), i_pt: 10})
 
 
 def test_sliced_indexbase_1d():

--- a/tests/test_printer_matrices.py
+++ b/tests/test_printer_matrices.py
@@ -2,18 +2,15 @@ import numpy as np
 import pytensor.tensor as pt
 import pytest
 from numpy.testing import assert_allclose
+from pytensor import config
 from pytensor.graph.basic import equal_computations
-from pytensor.scalar.basic import ScalarType
-from pytensor.tensor.elemwise import DimShuffle, Elemwise
-from pytensor.tensor.subtensor import AdvancedIncSubtensor
-from pytensor.tensor.variable import TensorVariable
 
 import sympy as sp
 from sympy.abc import x, y
 
 from sympytensor.pytensor import as_tensor, pytensor_function
 
-from tests.helpers import X, Y, Z, assert_graph_equal, get_pt_vars
+from tests.helpers import X, Y, Z, assert_graph_equal, assert_slice_equal, get_pt_vars
 
 
 def test_Trace():
@@ -42,36 +39,31 @@ def test_HadamardProduct():
 
 
 def test_MatMul():
-    expr = X * Y * Z
     cache = {}
-    expr_t = as_tensor(expr, cache=cache)
-    Xt, Yt, Zt = get_pt_vars(cache, ["X", "Y", "Z"])
-    expected = pt.dot(pt.dot(Xt, Yt), Zt)
-    assert_graph_equal(expr_t, expected)
+    expr_pt = as_tensor(X * Y * Z, cache=cache)
+    X_pt, Y_pt, Z_pt = get_pt_vars(cache, ["X", "Y", "Z"])
+    assert_graph_equal(expr_pt, pt.dot(pt.dot(X_pt, Y_pt), Z_pt))
 
 
 def test_Transpose():
-    assert isinstance(as_tensor(X.T).owner.op, DimShuffle)
+    cache = {}
+    expr_pt = as_tensor(X.T, cache=cache)
+    X_pt = get_pt_vars(cache, "X")
+    X_val = np.arange(16.0).reshape(4, 4)
+    assert_allclose(expr_pt.eval({X_pt: X_val}), X_val.T)
 
 
 def test_MatAdd():
-    expr = X + Y + Z
-    assert isinstance(as_tensor(expr).owner.op, Elemwise)
+    cache = {}
+    expr_pt = as_tensor(X + Y + Z, cache=cache)
+    X_pt, Y_pt, Z_pt = get_pt_vars(cache, ["X", "Y", "Z"])
+    values = [np.arange(16.0).reshape(4, 4) * scale for scale in (1, 2, 3)]
+    result = expr_pt.eval(dict(zip([X_pt, Y_pt, Z_pt], values)))
+    assert_allclose(result, sum(values))
 
 
 def test_slice():
     assert as_tensor(slice(1, 2, 3)) == slice(1, 2, 3)
-
-    def assert_slice_equal(s1, s2):
-        for attr in ["start", "stop", "step"]:
-            a1 = getattr(s1, attr)
-            a2 = getattr(s2, attr)
-            if a1 is None or a2 is None:
-                assert a1 is None and a2 is None, f"slice.{attr} mismatch: {a1} vs {a2}"
-            elif isinstance(a1, TensorVariable) and isinstance(a2, TensorVariable):
-                assert_graph_equal(a1, a2)
-            else:
-                assert a1 == a2, f"slice.{attr} mismatch: {a1} vs {a2}"
 
     dtypes = {x: "int32", y: "int32"}
     cache = {}
@@ -85,84 +77,109 @@ def test_slice():
     assert_slice_equal(actual_slice, slice(1, x_pt, 3))
 
 
-def test_MatrixSlice():
-    cache = {}
-
+def test_MatrixSlice_constant_bounds():
     n = sp.Symbol("n", integer=True)
     X = sp.MatrixSymbol("X", n, n)
 
-    Y = X[1:2:3, 4:5:6]
-    Yt = as_tensor(Y, cache=cache)
+    cache = {}
+    Y_pt = as_tensor(X[1:2:3, 4:5:6], cache=cache)
+    X_pt = get_pt_vars(cache, "X")
 
-    assert tuple(Yt.owner.op.idx_list) == (slice(0, 1, 2), slice(3, 4, 5))
-    assert Yt.owner.inputs[0] == as_tensor(X, cache=cache)
-    assert all(Yt.owner.inputs[i].data == i for i in range(1, 7))
+    X_val = np.arange(100.0).reshape(10, 10)
+    assert_allclose(Y_pt.eval({X_pt: X_val}), X_val[1:2:3, 4:5:6])
 
-    k = sp.Symbol("k")
-    start, stop, step = 4, k, 2
-    Y = X[start:stop:step]
-    Yt = as_tensor(Y, dtypes={n: "int32", k: "int32"})
-    stop_pos = Yt.owner.op.idx_list[0].stop
-    assert Yt.owner.inputs[1 + stop_pos].type == ScalarType("int32")
+
+def test_MatrixSlice_symbolic_bound():
+    n = sp.Symbol("n", integer=True)
+    k = sp.Symbol("k", integer=True)
+    X = sp.MatrixSymbol("X", n, n)
+
+    cache = {}
+    Y_pt = as_tensor(X[4:k:2], dtypes={n: "int32", k: "int32"}, cache=cache)
+    X_pt, k_pt, n_pt = get_pt_vars(cache, ["X", "k", "n"])
+
+    assert (k_pt.type.dtype, n_pt.type.dtype) == ("int32", "int32")
+
+    X_val = np.arange(100.0).reshape(10, 10)
+    result = Y_pt.eval({X_pt: X_val, k_pt: np.int32(9), n_pt: np.int32(10)})
+    assert_allclose(result, X_val[4:9:2, :])
 
 
 def test_BlockMatrix():
     n = sp.Symbol("n", integer=True)
     A, B, C, D = (sp.MatrixSymbol(name, n, n) for name in "ABCD")
     cache = {}
-    Block = sp.BlockMatrix([[A, B], [C, D]])
-    Blockt = as_tensor(Block, cache=cache)
-    At, Bt, Ct, Dt = get_pt_vars(cache, ["A", "B", "C", "D"])
-    solutions = [
-        pt.join(0, pt.join(1, At, Bt), pt.join(1, Ct, Dt)),
-        pt.join(1, pt.join(0, At, Ct), pt.join(0, Bt, Dt)),
+    block_pt = as_tensor(sp.BlockMatrix([[A, B], [C, D]]), cache=cache)
+    A_pt, B_pt, C_pt, D_pt = get_pt_vars(cache, ["A", "B", "C", "D"])
+    accepted_graphs = [
+        pt.join(0, pt.join(1, A_pt, B_pt), pt.join(1, C_pt, D_pt)),
+        pt.join(1, pt.join(0, A_pt, C_pt), pt.join(0, B_pt, D_pt)),
     ]
-    assert any(equal_computations([Blockt], [sol]) for sol in solutions)
+    assert any(equal_computations([block_pt], [graph]) for graph in accepted_graphs)
 
 
-def test_DenseMatrix():
+def jacobian_of_squares(symbols):
+    """Jacobian of ``[x**2 for x in symbols]`` -- a diagonal matrix holding ``2 * x``."""
+    return sp.Matrix([symbol**2 for symbol in symbols]).jacobian(symbols)
+
+
+@pytest.mark.parametrize("MatrixType", [sp.Matrix, sp.ImmutableMatrix], ids=["Matrix", "ImmutableMatrix"])
+def test_DenseMatrix(MatrixType):
     theta = sp.Symbol("theta")
-    for MatrixType in [sp.Matrix, sp.ImmutableMatrix]:
-        X = MatrixType([[sp.cos(theta), -sp.sin(theta)], [sp.sin(theta), sp.cos(theta)]])
-        cache = {}
-        tX = as_tensor(X, cache=cache)
-        assert isinstance(tX, TensorVariable)
-        assert isinstance(tX.owner.op, AdvancedIncSubtensor)
+    rotation = MatrixType([[sp.cos(theta), -sp.sin(theta)], [sp.sin(theta), sp.cos(theta)]])
 
-        theta_pt = get_pt_vars(cache, ["theta"])
-        theta_val = np.pi / 4
-        result = tX.eval({theta_pt: theta_val})
-        expected = np.array(
-            [
-                [np.cos(theta_val), -np.sin(theta_val)],
-                [np.sin(theta_val), np.cos(theta_val)],
-            ]
-        )
-        assert_allclose(result, expected)
+    cache = {}
+    X_pt = as_tensor(rotation, cache=cache)
+    theta_pt = get_pt_vars(cache, "theta")
+
+    theta_val = np.pi / 4
+    expected = np.array(
+        [
+            [np.cos(theta_val), -np.sin(theta_val)],
+            [np.sin(theta_val), np.cos(theta_val)],
+        ]
+    )
+    assert_allclose(X_pt.eval({theta_pt: theta_val}), expected)
+
+
+def test_dense_matrix_fills_numeric_base_then_sets_symbolic_entries():
+    """A symbolic dense matrix becomes a constant base plus one set-subtensor.
+
+    Stacking every cell would evaluate identically, so the structure is what
+    distinguishes the two strategies: the numeric entries have to be folded into the
+    constant base, leaving only the symbolic ones in the graph.
+    """
+    symbols = [sp.Symbol(f"x_{i}") for i in range(3)]
+
+    cache = {}
+    jacobian_pt = as_tensor(jacobian_of_squares(symbols), cache=cache)
+    x_pt = get_pt_vars(cache, [symbol.name for symbol in symbols])
+
+    diagonal = pt.as_tensor([0, 1, 2])
+    base = pt.as_tensor_variable(np.zeros((3, 3), dtype=config.floatX))
+    expected = base[diagonal, diagonal].set([2 * symbol_pt for symbol_pt in x_pt])
+
+    assert_graph_equal(jacobian_pt, expected)
 
 
 def test_empty_matrix():
     X = sp.Matrix([[0 for _ in range(20)] for _ in range(20)])
-    tX = as_tensor(X)
-    assert np.allclose(tX.eval(), np.zeros((20, 20)))
+    X_pt = as_tensor(X)
+    assert np.allclose(X_pt.eval(), np.zeros((20, 20)))
 
 
 def test_large_dense_matrix():
-    vars = [sp.Symbol(f"x_{i}") for i in range(100)]
+    symbols = [sp.Symbol(f"x_{i}") for i in range(100)]
 
-    eqs = sp.Matrix([x**2 for x in vars])
-    jac = eqs.jacobian(vars)
+    cache = {}
+    jacobian_pt = as_tensor(jacobian_of_squares(symbols), cache=cache)
+    values = np.arange(1.0, 1.0 + len(symbols))
+    symbol_values = dict(zip(get_pt_vars(cache, [symbol.name for symbol in symbols]), values))
 
-    jac_pt = as_tensor(jac)
+    assert_allclose(jacobian_pt.eval(symbol_values), np.diag(2 * values))
 
-    assert isinstance(jac_pt.owner.op, AdvancedIncSubtensor)
 
-    small_eqs = sp.Matrix([x**2 for x in vars[:3]])
-    small_jac = small_eqs.jacobian(vars[:3])
-    small_jac_pt = as_tensor(small_jac)
-
-    assert isinstance(small_jac_pt.owner.op, AdvancedIncSubtensor)
-
+def test_large_constant_matrix_is_folded():
     const_matrix = sp.ones(50, 50)
     const_pt = as_tensor(const_matrix)
     assert const_pt.owner is None
@@ -248,7 +265,7 @@ def test_Inverse_times_vector():
 def test_MatPow_large_exponent_uses_matrix_power():
     A = sp.MatrixSymbol("A", 3, 3)
     f = pytensor_function([A], [A**8], dims={A: 2})
-    dot_nodes = [n for n in f.maker.fgraph.toposort() if "dot" in type(n.op).__name__.lower()]
+    dot_nodes = [node for node in f.maker.fgraph.toposort() if "dot" in type(node.op).__name__.lower()]
     assert len(dot_nodes) <= 4
 
 

--- a/tests/test_printer_scalars.py
+++ b/tests/test_printer_scalars.py
@@ -126,6 +126,18 @@ def test_binary_mapping(f_sp, f_pt):
 
 
 @pytest.mark.parametrize(
+    "f_sp, expected",
+    [(sp.Max, 5.0), (sp.Min, -1.0)],
+    ids=["Max", "Min"],
+)
+def test_Max_Min_variadic(f_sp, expected):
+    cache = {}
+    result = as_tensor(f_sp(x, y, z), cache=cache)
+    x_pt, y_pt, z_pt = get_pt_vars(cache, ["x", "y", "z"])
+    assert_allclose(result.eval({x_pt: 2.0, y_pt: 5.0, z_pt: -1.0}), expected)
+
+
+@pytest.mark.parametrize(
     "f_sp, f_pt",
     [
         (sp.re, pt.real),

--- a/tests/test_printer_sparse.py
+++ b/tests/test_printer_sparse.py
@@ -30,11 +30,10 @@ def test_sparse_matrix():
 
 
 def test_dod_to_csr_empty():
-    data, idxs, pointers, shape = dod_to_csr({}, shape=(3, 4))
+    data, indices, indptr = dod_to_csr({}, shape=(3, 4))
     assert data == []
-    assert idxs == []
-    assert pointers == [0, 0, 0, 0]
-    assert shape == (3, 4)
+    assert indices == []
+    assert indptr == [0, 0, 0, 0]
 
 
 def test_sparse_matrix_with_empty_rows():

--- a/tests/test_printer_sparse.py
+++ b/tests/test_printer_sparse.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pytensor
 from numpy.testing import assert_allclose
 from scipy import sparse
 
@@ -16,17 +15,18 @@ def test_sparse_matrix():
     y = sp.SparseMatrix(2, 1, {(0, 0): a, (1, 0): b})
     z = X @ y
 
-    X_pt = as_tensor(X)
+    X_value = as_tensor(X).eval()
 
-    assert X_pt.owner.op == pytensor.sparse.CSR
-    assert sparse_allclose(X_pt.eval(), sparse.csr_matrix([[0, 2], [3, 0]]))
+    assert X_value.format == "csr"
+    assert sparse_allclose(X_value, sparse.csr_matrix([[0, 2], [3, 0]]))
 
     cache = {}
     z_pt = as_tensor(z, cache=cache)
     a_pt, b_pt = get_pt_vars(cache, ["a", "b"])
+    z_value = z_pt.eval({a_pt: 1, b_pt: 2})
 
-    assert z_pt.owner.op == pytensor.sparse.CSR
-    assert sparse_allclose(z_pt.eval({a_pt: 1, b_pt: 2}), sparse.csr_matrix([[4], [3]]))
+    assert z_value.format == "csr"
+    assert sparse_allclose(z_value, sparse.csr_matrix([[4], [3]]))
 
 
 def test_dod_to_csr_empty():

--- a/tests/test_pytensor_function.py
+++ b/tests/test_pytensor_function.py
@@ -54,6 +54,15 @@ def test_dim_handling():
     assert dim_handling([x], broadcastables={x: (False,)}) == {x: (False,)}
 
 
+def test_dim_handling_rejects_unknown_symbols():
+    with pytest.raises(ValueError, match=re.escape("`dims` contains symbols not in `inputs`: ['y']")):
+        dim_handling([x], dims={y: 1})
+
+
+def test_dim_handling_empty_dims():
+    assert dim_handling([x], dims={}) == {}
+
+
 @pytest.mark.parametrize(
     "kwargs, test_inputs, expected_result",
     [

--- a/tests/test_pytensor_function.py
+++ b/tests/test_pytensor_function.py
@@ -92,6 +92,19 @@ function_dim_cases = [
 ]
 
 
+UNKNOWN_DIM_LENGTH = 5
+
+
+def call_with_ones(f):
+    """Call a compiled function on all-ones inputs, returning its outputs as a list."""
+    in_values = [
+        np.ones(tuple(UNKNOWN_DIM_LENGTH if dim is None else dim for dim in var.type.shape)) for var in f.input_storage
+    ]
+    out_values = f(*in_values)
+
+    return out_values if isinstance(out_values, list) else [out_values]
+
+
 @pytest.mark.parametrize(
     "inputs, outputs, in_dims, out_dims",
     function_dim_cases,
@@ -99,18 +112,11 @@ function_dim_cases = [
 )
 def test_printing_scalar_function(inputs, outputs, in_dims, out_dims):
     f = pytensor_function(inputs, outputs, dims=in_dims)
-
     assert isinstance(f, Function)
 
-    in_values = [np.ones(tuple(d if d is not None else 5 for d in i.type.shape)) for i in f.input_storage]
-    out_values = f(*in_values)
-    if not isinstance(out_values, list):
-        out_values = [out_values]
+    out_values = call_with_ones(f)
 
-    assert len(out_dims) == len(out_values)
-    for d, value in zip(out_dims, out_values):
-        assert isinstance(value, np.ndarray)
-        assert value.ndim == d
+    assert [value.ndim for value in out_values] == out_dims
 
 
 def test_pytensor_function_raises_on_bad_kwarg():


### PR DESCRIPTION
`Max`/`Min` with more than two arguments blew up inside PyTensor's `make_node`, an `Idx` with a symbolic or infinite bound couldn't be printed at all, every use of a bounded index added a duplicate range check, and `dim_handling` quietly ignored `dims` keys missing from `inputs`. On the test side, assertions on op classes and on a positional graph-input index now check results instead — or graph structure where structure is the claim, since a dense matrix that stacks every cell evaluates identically to one that folds its numeric entries into a constant base.

All three commits were reviewed and merged already, but into this shared branch rather than main, which is what's left to correct.

`test_indexed_symbolic_shape` is a strict xfail — the remaining bare `int()` is in `_print_Indexed`, so whichever follow-up fixes that has to drop the marker or the suite goes red.
