### PR TITLE
Fix symbolic IndexedBase shapes and collapse a dead shape keyword

### DIFF
--- a/sympytensor/pytensor.py
+++ b/sympytensor/pytensor.py
@@ -380,17 +380,17 @@ class PytensorPrinter(Printer):
             # Printed on its own rather than through an ``Indexed``, so no caller-supplied shape is available.  Fall
             # back to the shape declared on the SymPy object, or to a 1-d tensor of unknown length if it has none.
             if X.shape is not None:
-                shape = tuple(int(x) if x is not None else None for x in X.shape)
+                shape = tuple(_static_dim(dim) for dim in X.shape)
             else:
                 shape = (None,)
 
         return self._get_or_create(X, dtype=dtype, shape=shape)
 
     def _print_Indexed(self, X, **kwargs):
-        # Infer the shape of the indexed base.
-        shape = X.base.shape
-        if shape is not None:
-            shape = tuple(int(x) if x is not None else None for x in X.shape)
+        # Infer the shape of the indexed base, keeping only its statically known dimensions.
+        base_shape = X.base.shape
+        if base_shape is not None:
+            shape = tuple(_static_dim(dim) for dim in base_shape)
         else:
             shape = (None,) * len(X.indices)
 

--- a/sympytensor/pytensor.py
+++ b/sympytensor/pytensor.py
@@ -374,15 +374,11 @@ class PytensorPrinter(Printer):
 
     def _print_IndexedBase(self, X, **kwargs):
         dtype = kwargs.get("dtypes", {}).get(X)
-        shape = kwargs.get("shapes", None)
-        bc = kwargs.get("broadcastable", None)
+        shape = kwargs.get("shape")
 
-        if bc is not None:
-            # An explicit broadcastable pattern from the caller takes precedence over any inferred shape.
-            shape = bc
-        elif shape is None:
-            # Nothing provided — infer from the SymPy object.  Use its declared shape when available, otherwise
-            # assume a 1-d tensor with unknown length.
+        if shape is None:
+            # Printed on its own rather than through an ``Indexed``, so no caller-supplied shape is available.  Fall
+            # back to the shape declared on the SymPy object, or to a 1-d tensor of unknown length if it has none.
             if X.shape is not None:
                 shape = tuple(int(x) if x is not None else None for x in X.shape)
             else:
@@ -394,15 +390,17 @@ class PytensorPrinter(Printer):
         # Infer the shape of the indexed base.
         shape = X.base.shape
         if shape is not None:
-            shape = tuple([int(x) if x is not None else None for x in X.shape])
+            shape = tuple(int(x) if x is not None else None for x in X.shape)
         else:
             shape = (None,) * len(X.indices)
 
-        bc = kwargs.get("broadcastables", {}).get(X.base, None)
-        if bc is None:
-            bc = shape
-        indices = tuple([self._print(x, **kwargs) for x in X.indices])
-        base = self._print(X.base, shape=shape, broadcastable=bc, **kwargs)
+        # An explicit broadcastable pattern for the base takes precedence over the inferred shape.
+        broadcastable = kwargs.get("broadcastables", {}).get(X.base)
+        if broadcastable is not None:
+            shape = broadcastable
+
+        indices = tuple(self._print(index, **kwargs) for index in X.indices)
+        base = self._print(X.base, shape=shape, **kwargs)
 
         return base[indices]
 

--- a/tests/test_printer_indexing.py
+++ b/tests/test_printer_indexing.py
@@ -46,7 +46,7 @@ def test_indexedbase_with_index():
     cache = {}
     x = as_tensor(sp.IndexedBase("x")[i, j], cache=cache)
     assert x.type.shape == ()
-    assert x.owner.inputs[0].ndim == 2
+    assert x.owner.inputs[0].type.shape == (None, None)
     assert len(cache) == 3
 
     i_pt, j_pt, x_pt = get_pt_vars(cache, ["i", "j", "x"])
@@ -63,12 +63,22 @@ def test_indexedbase_with_index_and_no_range():
     cache = {}
     x = as_tensor(sp.IndexedBase("x")[i, j], cache=cache)
     assert x.type.shape == ()
-    assert x.owner.inputs[0].ndim == 2
+    assert x.owner.inputs[0].type.shape == (None, None)
     assert len(cache) == 3
 
     i_pt, j_pt, x_pt = get_pt_vars(cache, ["i", "j", "x"])
 
     assert x.eval({x_pt: np.arange(20).reshape((10, 2)), i_pt: 5, j_pt: 1}) == 11.0
+
+
+def test_indexedbase_explicit_broadcastables_wins():
+    i = sp.Idx("i")
+    j = sp.Idx("j")
+    x = sp.IndexedBase("x", shape=(10, 10))
+
+    cache = {}
+    result = as_tensor(x[i, j], cache=cache, broadcastables={x: (True, False)})
+    assert result.owner.inputs[0].type.shape == (1, None)
 
 
 def test_Idx_non_concrete_bounds_unguarded():
@@ -110,13 +120,13 @@ def test_Idx_guard_emitted_once():
 def test_sliced_indexbase_1d():
     cache = {}
     x = sp.IndexedBase("x", shape=(10,))
-    x = as_tensor(x[7], cache=cache)
+    result = as_tensor(x[7], cache=cache)
     x_pt = get_pt_vars(cache, ["x"])
 
-    assert x.type.shape == ()
-    assert x.owner.inputs[0].type.shape == (10,)
+    assert result.type.shape == ()
+    assert result.owner.inputs[0].type.shape == (10,)
     assert len(cache) == 1
-    assert x.eval({x_pt: np.arange(10)}) == 7.0
+    assert result.eval({x_pt: np.arange(10)}) == 7.0
 
 
 def test_sliced_indexbase_2d():
@@ -128,7 +138,6 @@ def test_sliced_indexbase_2d():
 
     assert len(cache) == 1
     assert x1.type.shape == ()
-    assert x1.owner.inputs[0].ndim == 2
     assert x1.owner.inputs[0].type.shape == (10, 10)
     assert x1.eval({x_pt: np.arange(100).reshape(10, 10)}) == 1.0
     assert x2.eval({x_pt: np.arange(100).reshape(10, 10)}) == 54.0
@@ -252,8 +261,8 @@ def test_reduction_unsupported_op_raises():
 
 
 def test_negative_literal_index():
-    xb = sp.IndexedBase("x", shape=(10,))
+    x = sp.IndexedBase("x", shape=(10,))
     cache = {}
-    result = as_tensor(xb[-1], cache=cache)
+    result = as_tensor(x[-1], cache=cache)
     x_pt = get_pt_vars(cache, "x")
     assert_allclose(result.eval({x_pt: np.arange(10, dtype="float64")}), 9.0)

--- a/tests/test_printer_indexing.py
+++ b/tests/test_printer_indexing.py
@@ -92,10 +92,6 @@ def test_Idx_non_concrete_bounds_unguarded():
     assert x.eval({x_pt: np.arange(10.0), k_pt: 3}) == 3.0
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="_print_Indexed coerces base dimensions with a bare int(); fixed by the _static_dim read in commit 1.5",
-)
 def test_indexed_symbolic_shape():
     n = sp.Symbol("n", integer=True)
     i = sp.Idx("i")
@@ -103,6 +99,7 @@ def test_indexed_symbolic_shape():
     cache = {}
     x = as_tensor(sp.IndexedBase("A", shape=(n,))[i], cache=cache)
     assert x.type.shape == ()
+    assert x.owner.inputs[0].type.shape == (None,)
 
 
 def test_Idx_guard_emitted_once():


### PR DESCRIPTION
`IndexedBase` with a symbolic shape raised `TypeError: Cannot convert symbols to int` from a bare `int()`, on both the indexed and the bare path. The shape plumbing that hid it is gone too — `_print_IndexedBase` read a plural `shapes` keyword that nothing ever set, so the `shape=` its own caller passed was discarded, and the precedence between an explicit `broadcastables` entry and an inferred shape now resolves once, before the base is printed.
