### PR TITLE
Honor cache=None and suggest usable names in lookup errors

### DIFF
--- a/sympytensor/pymc.py
+++ b/sympytensor/pymc.py
@@ -82,8 +82,7 @@ def _resolve_model_value(model_value: str | TensorVariable, model: Model) -> Ten
         result = getattr(model, model_value, None)
         if result is None:
             raise AttributeError(
-                f"Variable '{model_value}' not found in the PyMC model. "
-                f"Available variables: {[v.name for v in model.value_vars]}"
+                f"Variable '{model_value}' not found in the PyMC model. Available variables: {sorted(model.named_vars)}"
             )
         return result
     raise TypeError(f"Replacement values must be TensorVariables or strings, got {type(model_value)}")

--- a/sympytensor/pytensor.py
+++ b/sympytensor/pytensor.py
@@ -114,18 +114,19 @@ class PytensorPrinter(Printer):
 
     Parameters
     ----------
-    cache : dict
-        Cache dictionary to use.  If ``None`` (default) will use the global cache.  To create a printer which does
-        not depend on or alter global state pass an empty dictionary.  Note: the dictionary is not copied on
-        initialization of the printer and will be updated in-place, so using the same dict object when creating
-        multiple printers or making multiple calls to :func:`as_tensor` or :func:`pytensor_function` means the cache
-        is shared between all these applications.
+    cache : dict, optional
+        Cache dictionary to use.  If ``None`` (the default) the module-level :data:`global_cache` is used.  To create a
+        printer which does not depend on or alter global state pass an empty dictionary.  Note: the dictionary is not
+        copied on initialization of the printer and will be updated in-place, so using the same dict object when
+        creating multiple printers or making multiple calls to :func:`as_tensor` or :func:`pytensor_function` means
+        the cache is shared between all these applications.
     """
 
     printmethod = "_pytensor"
 
     def __init__(self, *args, **kwargs):
-        self.cache = kwargs.pop("cache", {})
+        cache = kwargs.pop("cache", None)
+        self.cache = global_cache if cache is None else cache
 
         # Index range guards are memoized apart from `cache`, whose keys are 5-tuples that consumers unpack
         # positionally and whose size is part of the public contract.
@@ -604,9 +605,6 @@ def as_tensor(
     result : TensorVariable
         A variable corresponding to the expression's value in a PyTensor symbolic expression graph.
     """
-    if cache is None:
-        cache = global_cache
-
     return PytensorPrinter(cache=cache, settings={}).doprint(expr, **kwargs)
 
 
@@ -682,7 +680,9 @@ def pytensor_function(
         Sequence of expressions which constitute the output(s) of the function.  The free symbols of each expression
         must be a subset of `inputs`.
     cache : dict, optional
-        Cached PyTensor variables (see :attr:`PytensorPrinter.cache`).  Defaults to the module-level global cache.
+        Cached PyTensor variables (see :attr:`PytensorPrinter.cache`).  Deliberately defaults to a fresh empty
+        dictionary rather than to the :data:`global_cache` used by :func:`as_tensor`, so that a compiled function does
+        not share symbol identity with unrelated callers.  Pass ``cache=global_cache`` to opt into sharing.
     dtypes : dict, optional
         Passed to :meth:`PytensorPrinter.doprint`.
     broadcastables : dict of sympy.Symbol to tuple of bool, optional

--- a/tests/test_printer_cache.py
+++ b/tests/test_printer_cache.py
@@ -7,7 +7,7 @@ from pytensor.graph.traversal import ancestors
 import sympy as sp
 from sympy.abc import x, y, z
 
-from sympytensor.pytensor import as_tensor, global_cache
+from sympytensor.pytensor import PytensorPrinter, as_tensor, global_cache
 
 from tests.helpers import X, assert_graph_equal, f_t, get_pt_vars
 
@@ -38,6 +38,12 @@ def test_global_cache():
         assert as_tensor(s) is st
 
     assert len(global_cache) == 3
+
+
+def test_printer_cache_none_uses_global():
+    """An explicit ``None`` must resolve to the global cache, not be stored as ``None`` and fail on first lookup."""
+    assert PytensorPrinter(cache=None, settings={}).cache is global_cache
+    assert PytensorPrinter(settings={}).cache is global_cache
 
 
 def test_cache_types_distinct():

--- a/tests/test_pymc.py
+++ b/tests/test_pymc.py
@@ -1,3 +1,5 @@
+import ast
+
 import pymc as pm
 import pytensor.tensor as pt
 import pytest
@@ -5,7 +7,7 @@ import sympy as sp
 from numpy.testing import assert_allclose
 
 from sympytensor import SympyDeterministic, as_tensor
-from sympytensor.pymc import _match_cache_to_rvs
+from sympytensor.pymc import _match_cache_to_rvs, _resolve_model_value
 
 
 def test_match_rvs_to_symbols_simple():
@@ -202,10 +204,20 @@ def test_replacements_raises_missing_symbol_in_cache():
 def test_replacements_raises_missing_model_variable():
     x = sp.Symbol("x")
 
-    with pm.Model():
+    with pm.Model() as model:
         pm.Normal("z")
-        with pytest.raises(AttributeError, match="not found in the PyMC model"):
+        pm.HalfNormal("sigma")
+
+        with pytest.raises(AttributeError, match="not found in the PyMC model") as exc_info:
             SympyDeterministic("y", x + 1, replacements={"x": "nonexistent"})
+
+    suggested_names = ast.literal_eval(str(exc_info.value).split("Available variables: ")[1])
+
+    # Every suggested name must be accepted by the lookup that raised.  `sigma` is transformed, so suggesting from
+    # `model.value_vars` would print the unusable `sigma_log__` instead.
+    assert "sigma" in suggested_names
+    for name in suggested_names:
+        assert _resolve_model_value(name, model).name == name
 
 
 def test_replacements_raises_invalid_key_type():


### PR DESCRIPTION
`PytensorPrinter`'s docstring promised that `cache=None` uses the global cache; in fact the default was a fresh dict, and an explicit `None` got stored as-is and then raised on the first lookup. Separately, the replacement-lookup error suggested names from `model.value_vars`, which carry transform suffixes — someone following the message and passing `sigma_log__` hit the identical error, since the lookup is a `getattr` against the model's named variables.

`pytensor_function` keeps its fresh-dict default, now documented as deliberate rather than looking like the same oversight.
