### PR TITLE
Extract reduction helpers and delete unreachable printer code

### DIFF
--- a/sympytensor/pymc.py
+++ b/sympytensor/pymc.py
@@ -32,29 +32,34 @@ def _match_cache_to_rvs(cache: dict, model=None) -> dict:
     -------
     sub_dict : dict of TensorVariable to TensorVariable
         Mapping from the cached printer variables to the corresponding model random variables.
+
+    Raises
+    ------
+    ValueError
+        If any cached symbol has no matching model variable or deterministic.
     """
     global pm
     if pm is None:
         import pymc as pm
 
     pymc_model = pm.modelcontext(model)
-    found_params = []
-    var_names = [info[0] for info in cache.keys()]
+
+    # Iterate the cache rather than a name to variable lookup: two entries can share a symbol name at
+    # different shapes, and collapsing them by name would silently drop one of the substitutions.
     sub_dict = {}
+    found_names = set()
+    for cache_key, pytensor_var in cache.items():
+        symbol_name = cache_key[0]
+        model_var = getattr(pymc_model, symbol_name, None)
+        if model_var is not None:
+            found_names.add(symbol_name)
+            sub_dict[pytensor_var] = model_var
 
-    with pymc_model:
-        for info, pytensor_var in cache.items():
-            param_name, constructor, broadcast, dtype, shape = info
-            param = getattr(pymc_model, param_name, None)
-            if param is not None:
-                found_params.append(param.name)
-                sub_dict[pytensor_var] = param
-
-    missing_params = list(set(var_names) - set(found_params))
-    if len(missing_params) > 0:
+    missing_names = sorted({cache_key[0] for cache_key in cache} - found_names)
+    if missing_names:
         raise ValueError(
             "The following symbols were found in the provided sympy expression, but are not found among model "
-            "variables or deterministics: " + ", ".join(missing_params)
+            "variables or deterministics: " + ", ".join(missing_names)
         )
 
     return sub_dict

--- a/sympytensor/pytensor.py
+++ b/sympytensor/pytensor.py
@@ -208,6 +208,8 @@ class PytensorPrinter(Printer):
 
     def _print(self, expr, **kwargs):
         """Override base _print to add fast path for numeric types."""
+        # This fast path subsumes a `_print_Integer` method: every `sp.Integer` is intercepted here before
+        # dispatch can reach one.
         if isinstance(expr, sp.Integer):
             return expr.p
 
@@ -417,13 +419,16 @@ class PytensorPrinter(Printer):
         result : TensorVariable
             PyTensor variable representing the matrix.
         """
-        try:
-            elements = list(X.flat())
-            if all(isinstance(elem, sp.Basic) and elem.is_number for elem in elements):
+        elements = list(X.flat())
+        if all(isinstance(elem, sp.Basic) and elem.is_number for elem in elements):
+            try:
                 arr = np.array([float(elem.evalf()) for elem in elements], dtype=config.floatX)
+            except TypeError:
+                # A complex entry is `is_number` but does not coerce to a float; the element-wise path below
+                # prints it through the normal dispatch instead.
+                pass
+            else:
                 return pt.as_tensor_variable(arr.reshape(X.shape))
-        except (AttributeError, ValueError, TypeError):
-            pass
 
         return self._print_DenseMatrix_setsubtensor(X, **kwargs)
 
@@ -578,9 +583,6 @@ class PytensorPrinter(Printer):
         # Return value_1 if condition_1 else evaluate remaining conditions
         p_remaining = self._print(sp.Piecewise(*expr.args[1:]), **kwargs)
         return pt.switch(p_cond, p_e, p_remaining)
-
-    def _print_Integer(self, expr, **kwargs):
-        return expr.p
 
     def _print_factorial(self, expr, **kwargs):
         return self._print(sp.gamma(expr.args[0] + 1), **kwargs)

--- a/sympytensor/pytensor.py
+++ b/sympytensor/pytensor.py
@@ -100,6 +100,79 @@ def dod_to_csr(dod: dict[int, dict[int, Any]], shape: tuple[int, int]) -> tuple[
     return data, indices, indptr
 
 
+def _reduction_index_arrays(
+    sum_specs: dict[str, tuple[int, int]],
+    used_in_order: list[str],
+) -> dict[str, TensorVariable]:
+    """One :func:`pytensor.tensor.arange` per summation index, each broadcast onto its own leading axis.
+
+    Giving every index its own axis means the summand broadcasts correctly no matter which order the indices
+    appear in it, and the reduction can then collapse the leading ``len(used_in_order)`` axes.
+
+    Parameters
+    ----------
+    sum_specs : dict of str to tuple of int
+        Inclusive ``(start, stop)`` range for each summation index, keyed by index name.
+    used_in_order : list of str
+        Names of the indices that occur in the summand, in the order axes should be assigned to them.
+
+    Returns
+    -------
+    arrays : dict of str to TensorVariable
+        One index array per name in `used_in_order`.
+    """
+    n_used = len(used_in_order)
+    arrays = {}
+
+    for axis, name in enumerate(used_in_order):
+        start, stop = sum_specs[name]
+        index_range = pt.arange(start, stop + 1, dtype="int64")
+
+        if n_used > 1:
+            pattern = ["x"] * n_used
+            pattern[axis] = 0
+            index_range = index_range.dimshuffle(*pattern)
+
+        arrays[name] = index_range
+
+    return arrays
+
+
+def _apply_unused_index_factors(
+    result: TensorVariable,
+    sum_specs: dict[str, tuple[int, int]],
+    unused_names: list[str],
+    op: str,
+) -> TensorVariable:
+    r"""A summation index absent from the summand scales (Sum) or exponentiates (Product).
+
+    The summand is constant over such an index, so :math:`\sum_{i=a}^{b} c = c \, (b - a + 1)` and
+    :math:`\prod_{i=a}^{b} c = c^{\,b - a + 1}`.
+
+    Parameters
+    ----------
+    result : TensorVariable
+        Reduction result before the correction.
+    sum_specs : dict of str to tuple of int
+        Inclusive ``(start, stop)`` range for each summation index, keyed by index name.
+    unused_names : list of str
+        Names of the summation indices that do not occur in the summand.
+    op : {"sum", "prod"}
+        Reduction operation.
+
+    Returns
+    -------
+    result : TensorVariable
+        Reduction result corrected for the unused indices.
+    """
+    for name in unused_names:
+        start, stop = sum_specs[name]
+        size = stop - start + 1
+        result = result * size if op == "sum" else result**size
+
+    return result
+
+
 def _static_dim(dim: Any) -> int | None:
     """Coerce a statically known SymPy dimension to a Python ``int``, returning ``None`` for anything else.
 
@@ -438,35 +511,18 @@ class PytensorPrinter(Printer):
         sum_specs = {var.name: (int(start), int(stop)) for var, start, stop in sum_args}
         sum_index_names = [var.name for var, _, _ in sum_args]
 
-        used = {sym.name for sym in summand.free_symbols if isinstance(sym, sp.Idx) and sym.name in sum_specs}
-        used_in_order = [name for name in sum_index_names if name in used]
-        n_used = len(used_in_order)
+        used_names = {sym.name for sym in summand.free_symbols if isinstance(sym, sp.Idx) and sym.name in sum_specs}
+        used_in_order = [name for name in sum_index_names if name in used_names]
+        unused_names = [name for name in sum_index_names if name not in used_names]
 
-        sum_idx_arrays = {}
-        for axis, name in enumerate(used_in_order):
-            start, stop = sum_specs[name]
-            rng = pt.arange(start, stop + 1, dtype="int64")
-            if n_used > 1:
-                pattern = ["x"] * n_used
-                pattern[axis] = 0
-                rng = rng.dimshuffle(*pattern)
-            sum_idx_arrays[name] = rng
+        summand_kwargs = {**kwargs, "_sum_idx_arrays": _reduction_index_arrays(sum_specs, used_in_order)}
+        result = self._print(summand, **summand_kwargs)
 
-        kwargs_with_arrays = {**kwargs, "_sum_idx_arrays": sum_idx_arrays}
-        result = self._print(summand, **kwargs_with_arrays)
-
-        if n_used:
+        if used_in_order:
             reducer = pt.sum if op == "sum" else pt.prod
-            result = reducer(result, axis=tuple(range(n_used)))
+            result = reducer(result, axis=tuple(range(len(used_in_order))))
 
-        for name in sum_index_names:
-            if name in used:
-                continue
-            start, stop = sum_specs[name]
-            size = stop - start + 1
-            result = result * size if op == "sum" else result**size
-
-        return result
+        return _apply_unused_index_factors(result, sum_specs, unused_names, op)
 
     def _print_Sum(self, X, **kwargs) -> TensorVariable:
         """Convert SymPy Sum to PyTensor sum reduction."""

--- a/sympytensor/pytensor.py
+++ b/sympytensor/pytensor.py
@@ -61,8 +61,8 @@ mapping = {
     sp.HadamardProduct: pt.mul,
     sp.Trace: pt.trace,
     sp.Determinant: pt.linalg.det,
-    sp.Inverse: pt.linalg.inv,
     sp.Transpose: pt.matrix_transpose,
+    # sp.Inverse is handled by _print_Inverse; it subclasses sp.MatPow and must not reach this mapping.
 }
 
 

--- a/tests/test_printer_indexing.py
+++ b/tests/test_printer_indexing.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytensor.tensor as pt
 import pytest
 from numpy.testing import assert_allclose
 from pytensor.graph.traversal import ancestors
@@ -6,7 +7,7 @@ from pytensor.raise_op import CheckAndRaise
 
 import sympy as sp
 
-from sympytensor.pytensor import PytensorPrinter, as_tensor
+from sympytensor.pytensor import PytensorPrinter, _apply_unused_index_factors, _reduction_index_arrays, as_tensor
 
 from tests.helpers import get_pt_vars
 
@@ -263,3 +264,42 @@ def test_negative_literal_index():
     result = as_tensor(x[-1], cache=cache)
     x_pt = get_pt_vars(cache, "x")
     assert_allclose(result.eval({x_pt: np.arange(10, dtype="float64")}), 9.0)
+
+
+@pytest.mark.parametrize(
+    "used_in_order, expected_shapes",
+    [
+        (["i"], {"i": (3,)}),
+        (["i", "j"], {"i": (3, 1), "j": (1, 4)}),
+        (["j", "i"], {"j": (4, 1), "i": (1, 3)}),
+    ],
+    ids=["one_index_undimshuffled", "i_first", "j_first"],
+)
+def test_reduction_index_arrays_axes(used_in_order, expected_shapes):
+    arrays = _reduction_index_arrays({"i": (0, 2), "j": (1, 4)}, used_in_order)
+    values = {name: array.eval() for name, array in arrays.items()}
+
+    assert {name: value.shape for name, value in values.items()} == expected_shapes
+
+    expected_ranges = {"i": [0, 1, 2], "j": [1, 2, 3, 4]}
+    for name, value in values.items():
+        assert_allclose(value.ravel(), expected_ranges[name])
+
+
+@pytest.mark.parametrize(
+    "unused_names, op, expected",
+    [
+        (["i"], "sum", 3.0 * 5),
+        (["i"], "prod", 3.0**5),
+        (["i", "k"], "sum", 3.0 * 5 * 3),
+        (["i", "k"], "prod", (3.0**5) ** 3),
+        ([], "sum", 3.0),
+    ],
+    ids=["sum_one", "prod_one", "sum_two", "prod_two", "none_unused"],
+)
+def test_apply_unused_index_factors(unused_names, op, expected):
+    # "i" ranges over 5 values and "k" over 3.
+    sum_specs = {"i": (0, 4), "k": (2, 4)}
+    result = _apply_unused_index_factors(pt.as_tensor(3.0), sum_specs, unused_names, op)
+
+    assert_allclose(result.eval(), expected)

--- a/tests/test_pymc.py
+++ b/tests/test_pymc.py
@@ -25,6 +25,23 @@ def test_match_rvs_to_symbols_simple():
         assert sub_dict[var_pt] == var_pm
 
 
+def test_match_cache_to_rvs_duplicate_names():
+    cache = {}
+    as_tensor(sp.IndexedBase("x", shape=(10, 10)), cache=cache)
+    as_tensor(sp.IndexedBase("x", shape=(10, 7)), cache=cache)
+
+    # Guards the assertions below: were the two shapes to stop caching separately, a lookup that collapses
+    # entries by name would satisfy them trivially instead of dropping a substitution.
+    assert len(cache) == 2
+
+    with pm.Model():
+        x_pm = pm.Normal("x")
+        sub_dict = _match_cache_to_rvs(cache)
+
+    assert set(sub_dict) == set(cache.values())
+    assert set(sub_dict.values()) == {x_pm}
+
+
 def test_make_sympy_deterministic_simple():
     x_sp = sp.Symbol("x")
     y_sp = x_sp + 1


### PR DESCRIPTION
Refactor only — no behavior change, and the test diff is additive so the existing suite is the check. `_print_reduction` was carrying four jobs at once; the two that are pure functions of their arguments are now module-level and unit-tested directly. `_match_cache_to_rvs` loses a `with pymc_model:` block that only wrapped `getattr` calls, so it was mutating PyMC's context stack for nothing, and its error message now sorts the missing names instead of printing set order.

Two dead things go: the `sp.Inverse` entry in `mapping`, unreachable because `_print_Inverse` shadows it, and `_print_Integer`, unreachable because `_print` intercepts `sp.Integer` first.

`_print_DenseMatrix`'s bare `except (AttributeError, ValueError, TypeError)` keeps only `TypeError` — that one is genuinely reachable, since a complex entry is `is_number` but not `float()`-able — and the `return` moves to an `else` so a `TypeError` raised by `reshape` is no longer swallowed on the way past.
