### PR TITLE
Add a measured Ruff lint gate and drop dead tool config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,9 +10,9 @@ repos:
     -   id: trailing-whitespace
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.11.0
+  rev: v0.16.1
   hooks:
-    - id: ruff
+    - id: ruff-check
       args: [ --fix, --unsafe-fixes, --exit-non-zero-on-fix ]
     - id: ruff-format
       types_or: [ python, pyi, jupyter]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,3 +65,14 @@ filterwarnings = ["error"]
 line-length = 120
 target-version = "py312"
 extend-exclude = ["sympytensor/_version.py", "setup.py"]
+
+[tool.ruff.lint]
+select = ["E4", "E7", "E9", "F", "B", "C901", "ARG", "SIM", "UP", "RET"]
+
+[tool.ruff.lint.mccabe]
+max-complexity = 10
+
+[tool.ruff.lint.per-file-ignores]
+# Every ``_print_*`` handler must accept the printer's dispatch signature, so the
+# ones that need no keyword arguments still declare ``**kwargs``.
+"sympytensor/pytensor.py" = ["ARG002"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dev = [
     "pre-commit",
     "pytest",
     "pytest-cov",
+    "ruff==0.16.1",
 ]
 
 [tool.hatch.version]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,18 +61,7 @@ minversion = "6.0"
 xfail_strict=true
 filterwarnings = ["error"]
 
-[tool.isort]
-profile = 'black'
-
-[tool.black]
-line-length = 120
-
-[tool.nbqa.mutate]
-isort = 1
-black = 1
-pyupgrade = 1
-
 [tool.ruff]
 line-length = 120
-target-version = "py310"
+target-version = "py312"
 extend-exclude = ["sympytensor/_version.py", "setup.py"]

--- a/sympytensor/pymc.py
+++ b/sympytensor/pymc.py
@@ -173,7 +173,7 @@ def SympyDeterministic(
 
     Returns
     -------
-    expr_pm : TensorVariable
+    deterministic : TensorVariable
         The new deterministic variable registered in the model.
     """
     global pm
@@ -201,6 +201,4 @@ def SympyDeterministic(
     replace_dict = {**auto_dict, **explicit_dict}
 
     pymc_expr = graph_replace(pytensor_expr, replace_dict, strict=True)
-    expr_pm = pm.Deterministic(name=name, var=pymc_expr, model=model, dims=dims)
-
-    return expr_pm
+    return pm.Deterministic(name=name, var=pymc_expr, model=model, dims=dims)

--- a/sympytensor/pytensor.py
+++ b/sympytensor/pytensor.py
@@ -458,20 +458,15 @@ class PytensorPrinter(Printer):
         if shape is None:
             # Printed on its own rather than through an ``Indexed``, so no caller-supplied shape is available.  Fall
             # back to the shape declared on the SymPy object, or to a 1-d tensor of unknown length if it has none.
-            if X.shape is not None:
-                shape = tuple(_static_dim(dim) for dim in X.shape)
-            else:
-                shape = (None,)
+            shape = tuple(_static_dim(dim) for dim in X.shape) if X.shape is not None else (None,)
 
         return self._get_or_create(X, dtype=dtype, shape=shape)
 
     def _print_Indexed(self, X, **kwargs):
         # Infer the shape of the indexed base, keeping only its statically known dimensions.
         base_shape = X.base.shape
-        if base_shape is not None:
-            shape = tuple(_static_dim(dim) for dim in base_shape)
-        else:
-            shape = (None,) * len(X.indices)
+        unknown_shape = (None,) * len(X.indices)
+        shape = tuple(_static_dim(dim) for dim in base_shape) if base_shape is not None else unknown_shape
 
         # An explicit broadcastable pattern for the base takes precedence over the inferred shape.
         broadcastable = kwargs.get("broadcastables", {}).get(X.base)

--- a/tests/test_printer_matrices.py
+++ b/tests/test_printer_matrices.py
@@ -58,7 +58,7 @@ def test_MatAdd():
     expr_pt = as_tensor(X + Y + Z, cache=cache)
     X_pt, Y_pt, Z_pt = get_pt_vars(cache, ["X", "Y", "Z"])
     values = [np.arange(16.0).reshape(4, 4) * scale for scale in (1, 2, 3)]
-    result = expr_pt.eval(dict(zip([X_pt, Y_pt, Z_pt], values)))
+    result = expr_pt.eval(dict(zip([X_pt, Y_pt, Z_pt], values, strict=True)))
     assert_allclose(result, sum(values))
 
 
@@ -174,7 +174,7 @@ def test_large_dense_matrix():
     cache = {}
     jacobian_pt = as_tensor(jacobian_of_squares(symbols), cache=cache)
     values = np.arange(1.0, 1.0 + len(symbols))
-    symbol_values = dict(zip(get_pt_vars(cache, [symbol.name for symbol in symbols]), values))
+    symbol_values = dict(zip(get_pt_vars(cache, [symbol.name for symbol in symbols]), values, strict=True))
 
     assert_allclose(jacobian_pt.eval(symbol_values), np.diag(2 * values))
 

--- a/tests/test_pymc.py
+++ b/tests/test_pymc.py
@@ -20,9 +20,9 @@ def test_match_rvs_to_symbols_simple():
         as_tensor(y_sp, cache=cache)
         sub_dict = _match_cache_to_rvs(cache)
 
-    pymc_vars = [x_pm]
-    for var_pt, var_pm in zip(cache.values(), pymc_vars):
-        assert sub_dict[var_pt] == var_pm
+    # Unpacking asserts the printer cached exactly one variable for ``x``.
+    (printed_x,) = cache.values()
+    assert sub_dict[printed_x] is x_pm
 
 
 def test_match_cache_to_rvs_duplicate_names():


### PR DESCRIPTION
Ruff was running with default rules only — no `[tool.ruff.lint]` table at all — so a CC-14 function and a pile of dead config sailed through pre-commit for as long as they existed. The select list here is measured rather than guessed: the full candidate set turns up 8 violations across the package, all fixed in the commit before the gate goes in, so `ruff check` is clean at every commit. `max-complexity = 10` lands with headroom; the highest in the package is 5.

`target-version` said py310 against `requires-python = ">=3.12"`. `[tool.black]`, `[tool.isort]` and `[tool.nbqa.mutate]` are gone — pre-commit runs ruff-format, and there are no notebooks and no nbqa hook for the last one to configure.

The one carve-out is `ARG002` in the printer module: every `_print_*` handler has to accept the dispatch signature, so the couple that need no keyword arguments still declare `**kwargs`.
